### PR TITLE
Update ORMTranslatableListener.php

### DIFF
--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -61,7 +61,7 @@ final class ORMTranslatableListener implements EventSubscriber
         $classMetadata = $eventArgs->getClassMetadata();
         $reflection = $classMetadata->getReflectionClass();
 
-        if ($reflection->isAbstract()) {
+        if (!$reflection || $reflection->isAbstract()) {
             return;
         }
 


### PR DESCRIPTION
Running make:entity will cause PHP Fatal error if $reflection is null. This fix, as suggested by others, will avoid evaluation of $reflection->isAbstract() if $reflection is null.